### PR TITLE
Remove docker debug output polluting the view

### DIFF
--- a/dox/runner.py
+++ b/dox/runner.py
@@ -82,8 +82,6 @@ class Runner(object):
 
     def _docker_cmd(self, *args):
         base_docker = ['docker']
-        if self.args.debug:
-            base_docker.append('-D')
         try:
             self._run_shell_command(base_docker + list(args))
         except Exception as e:


### PR DESCRIPTION
With the -D flag present, the only extra output is:
    time="2015-12-17T10:50:24+01:00" level=debug msg="framesize: 74"
between every single STDOUT line. This shouldn't be needed, as you would expect the debug to influence dox things, not Docker